### PR TITLE
Rename analysis layer type

### DIFF
--- a/bundles/mapping/mapanalysis/domain/AnalysisLayer.js
+++ b/bundles/mapping/mapanalysis/domain/AnalysisLayer.js
@@ -11,7 +11,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapanalysis.domain.AnalysisLayer
  */
     function () {
     /* Layer Type */
-        this._layerType = 'ANALYSIS';
+        this._layerType = 'analysislayer'; // 'ANALYSIS';
         this._metaType = 'ANALYSIS';
     }, {
         /* Layer type specific functions */
@@ -80,6 +80,9 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapanalysis.domain.AnalysisLayer
      */
         getOverrideSld: function () {
             return this._override_sld;
+        },
+        isFilterSupported: function () {
+            return true;
         }
 
     }, {

--- a/bundles/mapping/mapanalysis/plugin/AnalysisLayerPlugin.ol.js
+++ b/bundles/mapping/mapanalysis/plugin/AnalysisLayerPlugin.ol.js
@@ -26,7 +26,7 @@ Oskari.clazz.define(
         layertype: 'analysislayer',
 
         getLayerTypeSelector: function () {
-            return 'ANALYSIS';
+            return this.layertype; // 'ANALYSIS';
         },
 
         /**


### PR DESCRIPTION
So type in layer matched the type in plugin ('analysislayer') instead of having analysislayer and ANALYSIS as types. This fixes an issue with #17 that analysis layers were NOT shown with the new WFS-plugin.

Note! Requires changes in oskari-frontend as well.