### PR TITLE
Set analysis layer render mode

### DIFF
--- a/bundles/mapping/mapanalysis/domain/AnalysisLayerModelBuilder.js
+++ b/bundles/mapping/mapanalysis/domain/AnalysisLayerModelBuilder.js
@@ -69,6 +69,8 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapanalysis.domain.AnalysisLayer
 
         // call parent parseLayerData
         this.wfsBuilder.parseLayerData(layer, mapLayerJson, maplayerService);
+        this.wfsBuilder.setDefaultRenderMode(layer, 'vector');
+
         if (mapLayerJson.fields) {
             layer.setFields(mapLayerJson.fields);
         }


### PR DESCRIPTION
Set `vector` render mode on analysis layers.
Requires https://github.com/oskariorg/oskari-frontend/pull/871