### PR TITLE
Update error messages when attempted to add WFS version 3.0 maplayer to analysis

### DIFF
--- a/bundles/analysis/analyse/instance.js
+++ b/bundles/analysis/analyse/instance.js
@@ -239,7 +239,7 @@ Oskari.clazz.define(
                 if (this.analyse && this.analyse.isEnabled && this._wfsLayerHasUnsupportedVersion(event.getMapLayer())) {
                     this.showMessage(
                         loc.error.title,
-                        loc.error.invalidSetup
+                        loc.error.not_supported_WFS_3_0_maplayer
                     );
                     this._log.warn('tried to add unsupported wfs version to analysis');
                 } else if (this.analyse && this.analyse.isEnabled) {

--- a/bundles/analysis/analyse/resources/locale/en.js
+++ b/bundles/analysis/analyse/resources/locale/en.js
@@ -372,7 +372,8 @@ Oskari.registerLocalization(
                 "Unable_to_get_analysisLayer_data": "The source data could not be retrieved.",
                 "timeout": "Processing the analysis could not be finished because of a time-out error.",
                 "error": "The analysis failed.",
-                "parsererror": "The result data are invalid."
+                "parsererror": "The result data are invalid.",
+                "not_supported_WFS_3_0_maplayer": "This map layer (WFS 3.0) is unfortunately not supported in analysis."
             },
             "infos": {
                 "title": "Too many attributes",

--- a/bundles/analysis/analyse/resources/locale/fi.js
+++ b/bundles/analysis/analyse/resources/locale/fi.js
@@ -372,7 +372,8 @@ Oskari.registerLocalization(
                 "Unable_to_get_analysisLayer_data": "Analyysin lähtötietoja ei voitu hakea.",
                 "timeout": "Analyysin laskenta keskeytyi aikakatkaisun vuoksi.",
                 "error": "Analyysi epäonnistui.",
-                "parsererror": "Analyysin lopputuloksessa on virheitä."
+                "parsererror": "Analyysin lopputuloksessa on virheitä.",
+                "not_supported_WFS_3_0_maplayer" : "Tätä karttatasoa (WFS 3.0) ei valitettavasti tueta analyysissä."
             },
             "infos": {
                 "title": "Liikaa ominaisuustietoja",

--- a/bundles/analysis/analyse/resources/locale/sv.js
+++ b/bundles/analysis/analyse/resources/locale/sv.js
@@ -372,7 +372,8 @@ Oskari.registerLocalization(
                 "Unable_to_get_analysisLayer_data": "Ursprungsdata kunde inte laddas.",
                 "timeout": "Analys misslyckades beroende på tidsutlösning.",
                 "error": "Analys misslyckades.",
-                "parsererror": "Det finns fel i resultaten."
+                "parsererror": "Det finns fel i resultaten.",
+                "not_supported_WFS_3_0_maplayer": "Tyvärr stöder analysen inte detta kartlager (WFS 3.0)."
             },
             "infos": {
                 "title": "För många attributer",


### PR DESCRIPTION
Update error messages displayed to user when attempted to add WFS version 3.0 maplayer to analysis