### PR TITLE
Only load analysis layers when logged in

### DIFF
--- a/bundles/analysis/analyse/instance.js
+++ b/bundles/analysis/analyse/instance.js
@@ -136,7 +136,9 @@ Oskari.clazz.define(
             me._createUi();
 
             // Load analysis layers
-            me.analyseService.loadAnalyseLayers();
+            if (Oskari.user().isLoggedIn()) {
+                me.analyseService.loadAnalyseLayers();
+            }
 
             /* stateful */
             if (conf && conf.stateful === true) {


### PR DESCRIPTION
Since server will respond with an error instead of empty list for guest users in near future.