### PR TITLE
Refresh layers content panel on handleAnalyseMapResponse

### DIFF
--- a/bundles/analysis/analyse/view/StartAnalyse.ol.js
+++ b/bundles/analysis/analyse/view/StartAnalyse.ol.js
@@ -2763,6 +2763,7 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
                         }
                     }
                 }
+                me.refreshAnalyseData(mapLayer.getId());
             }
         },
 


### PR DESCRIPTION
PR contains change to refresh layers content panel on handleAnalyseMapResponse by using existing functions. Change is added to keep map layer selected and with this prevent errors on subsequent analysis when map layer under analysis is not selected.