### PR TITLE
Fix layer eligible to analysis check

### DIFF
--- a/bundles/analysis/analyse/view/ContentPanel.ol.js
+++ b/bundles/analysis/analyse/view/ContentPanel.ol.js
@@ -654,6 +654,10 @@ Oskari.clazz.define(
                         formattedFeature.properties = {};
                     }
                     return formattedFeature;
+                },
+                getVersion: function (){
+                    // Version is added just to make fake layer compatible with other layers
+                    return '0.0.1';
                 }
             };
         },

--- a/bundles/analysis/analyse/view/StartAnalyse.ol.js
+++ b/bundles/analysis/analyse/view/StartAnalyse.ol.js
@@ -1204,16 +1204,15 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
         _eligibleForAnalyse: function (layer) {
             return (((layer.hasFeatureData && layer.hasFeatureData()) ||
                 layer.isLayerOfType(this.contentPanel.getLayerType())) && 
-                    this._layerTypeIsEligibleForAnalyse(layer.getLayerType()) &&
-                    this._wfsLayerHasSupportedVersion(layer.getVersion()));
+                    this._layerHasSupportedVersion(layer.getLayerType(),layer.getVersion()));
         },
 
-        _layerTypeIsEligibleForAnalyse(layerType) {
-            return layerType === 'wfs' || layerType === 'analysislayer';
-        },
-
-        _wfsLayerHasSupportedVersion(layerVersion){
-            return layerVersion !== this._unsupportedWfsLayerVersion;
+        _layerHasSupportedVersion(layerType,layerVersion){
+            if(layerType === 'wfs' &&
+                layerVersion === this._unsupportedWfsLayerVersion){
+                    return false;
+            }
+            return true;
         },
 
         /**

--- a/bundles/analysis/analyse/view/StartAnalyse.ol.js
+++ b/bundles/analysis/analyse/view/StartAnalyse.ol.js
@@ -1208,7 +1208,7 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
         },
 
         _layerHasSupportedVersion(layerType,layerVersion){
-            if(layerType === 'wfs' &&
+            if((layerType === 'wfs' || layerType === 'analysislayer') &&
                 layerVersion === this._unsupportedWfsLayerVersion){
                     return false;
             }


### PR DESCRIPTION
Originally layer type check was added to prevent adding wfs 3.0.0 layers to analysis. This functionality was poorly implemented and caused analysis layers and temp layers not to be included in analysis layer list. In this fix layer type is only checked when determining is layer version suitable for analysis.