### PR TITLE
Changes to content-editor for it to function with the new WFS

### DIFF
--- a/bundles/tampere/content-editor/instance.js
+++ b/bundles/tampere/content-editor/instance.js
@@ -222,6 +222,11 @@ Oskari.clazz.define('Oskari.tampere.bundle.content-editor.ContentEditorBundleIns
          * @static
          */
         eventHandlers: {
+            FeatureEvent: function (event) {
+                if (this.sideContentEditor != null && event.getOperation() == 'click') {
+                    this.sideContentEditor.parseWFSFeatureGeometries(event);
+                }
+            },
             GetInfoResultEvent: function (evt) {
                 if (this.sideContentEditor != null) {
                     var data = evt.getData();
@@ -238,11 +243,6 @@ Oskari.clazz.define('Oskari.tampere.bundle.content-editor.ContentEditorBundleIns
                         var event = eventBuilder(featuresIds, layer, true);
                         this.sandbox.notifyAll(event);
                     }
-                }
-            },
-            WFSFeatureGeometriesEvent: function (evt) {
-                if (this.sideContentEditor != null) {
-                    this.sideContentEditor.parseWFSFeatureGeometries(evt);
                 }
             },
             MapClickedEvent: function (event) {
@@ -270,6 +270,7 @@ Oskari.clazz.define('Oskari.tampere.bundle.content-editor.ContentEditorBundleIns
                     var maplayer = evt.getMapLayer();
                     var featureIds = evt.getWfsFeatureIds();
                     var features = [];
+
                     featureIds.forEach(function(fid) {
                         var filtered = maplayer.getActiveFeatures().filter(function(feature){
                             return feature[0] === fid;
@@ -279,6 +280,7 @@ Oskari.clazz.define('Oskari.tampere.bundle.content-editor.ContentEditorBundleIns
                         });
                     });
                     this.sideContentEditor._handleInfoResult({layerId: maplayer.getId(), features: features});
+                    
                 }
             }
         },


### PR DESCRIPTION
- Removal of WFSFeatureGeometriesEvent because it doesn't work properly with new WFS (doesn't get geometries)

- Added FeatureEvent to replace WFSFeatureGeometriesEvent in getting geometries

- Changing the code of getting geometries to work with FeatureEvent (wkt -> geojson)

- Commented out "deleteTileCache" because it currently does nothing

- Removed "_findGeometryByFidFromLayer" because it used the old WFS way to get geometries, and added error message to "_findGeometryByFid" if it fails

- Removed "_handleInfoResult" from "setClickCoords" because it doesn't seem to do anything except empty the already filled info results from side panel because the calling order of events have changed

- Couple other fixes related to not giving function a value for "deleteFeature"