### PR TITLE
Analysis add interactions fix

### DIFF
--- a/bundles/analysis/analyse/view/DrawControls.js
+++ b/bundles/analysis/analyse/view/DrawControls.js
@@ -195,6 +195,7 @@ Oskari.clazz.define(
                     'id': 'oskari_analysis_analyse_view_analyse_content_features_' + tool
                 });
                 toolDiv.on('click', function () {
+                    me.closeHelpDialog();
                     // if selection tool is left active, deactivate it
                     me.deactivateSelectTools();
 
@@ -375,10 +376,7 @@ Oskari.clazz.define(
         closeHelpDialog: function () {
             if (this.helpDialog) {
                 this.helpDialog.close(true);
-                delete this.helpDialog;
-                if (this.mapModule.getDrawingMode()) {
-                    this.drawStopper(true);
-                }
+                this.helpDialog = null;
             }
         },
 

--- a/bundles/analysis/analyse/view/StartAnalyse.ol.js
+++ b/bundles/analysis/analyse/view/StartAnalyse.ol.js
@@ -2289,7 +2289,6 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
         refreshAnalyseData: function (layer_id) {
             // Remove old
             this.contentPanel.emptyLayers();
-            this.contentPanel._activateSelectControls();
             this._addAnalyseData(this.contentPanel, layer_id);
         },
 


### PR DESCRIPTION
Add interactions to map on startdrawing not in refreshAnalyseData. Fixes issue where adding new layer refreshes analysis data and ol doesn't like adding dublicate interactions.
Also fixed start/stopdrawing calls because cancelling drawing broke adding features functionality.
Changed to enable clear feature button if analysis layer has features in featureevent