### PR TITLE
Analysis layer constructor fix

### DIFF
--- a/bundles/mapping/mapanalysis/domain/AnalysisLayer.js
+++ b/bundles/mapping/mapanalysis/domain/AnalysisLayer.js
@@ -6,7 +6,7 @@ const WFSLayer = Oskari.clazz.get('Oskari.mapframework.bundle.mapwfs2.domain.WFS
  */
 export class AnalysisLayer extends WFSLayer {
     constructor () {
-        super();
+        super(...arguments);
         /* Layer Type */
         this._layerType = 'analysislayer'; // 'ANALYSIS';
         this._metaType = 'ANALYSIS';


### PR DESCRIPTION
Pass arguments to super constructor. Fixes issue where analysis layer's style wasn't shown correctly.