### PR TITLE
Analysis show attribute infos

### DIFF
--- a/bundles/analysis/analyse/instance.js
+++ b/bundles/analysis/analyse/instance.js
@@ -523,8 +523,8 @@ Oskari.clazz.define(
             var dialog = Oskari.clazz.create(
                 'Oskari.userinterface.component.Popup'
             );
-            dialog.show(title, message, [dialog.createCloseButton()]);
-            dialog.fadeout(8000);
+            dialog.show(title, message);
+            dialog.fadeout(5000);
         },
 
         /**

--- a/bundles/analysis/analyse/instance.js
+++ b/bundles/analysis/analyse/instance.js
@@ -239,7 +239,7 @@ Oskari.clazz.define(
                 this.isMapStateChanged = true;
                 if (this.analyse && this.analyse.isEnabled) {
                     const maplayer = event.getMapLayer();
-                    if (this._wfsLayerHasUnsupportedVersion(maplayer)) {
+                    if (this.wfsLayerHasUnsupportedVersion(maplayer)) {
                         const loc = this.getLocalization('AnalyseView');
                         this.showMessage(
                             loc.error.title,
@@ -290,7 +290,7 @@ Oskari.clazz.define(
             }
         },
 
-        _wfsLayerHasUnsupportedVersion(layer){
+        wfsLayerHasUnsupportedVersion(layer){
             return layer.getLayerType() === 'wfs' && this._unsupportedWfsLayerVersions.includes(layer.getVersion());
         },
         /**
@@ -523,8 +523,8 @@ Oskari.clazz.define(
             var dialog = Oskari.clazz.create(
                 'Oskari.userinterface.component.Popup'
             );
-            dialog.show(title, message);
-            dialog.fadeout(5000);
+            dialog.show(title, message, [dialog.createCloseButton()]);
+            dialog.fadeout(8000);
         },
 
         /**

--- a/bundles/analysis/analyse/resources/locale/en.js
+++ b/bundles/analysis/analyse/resources/locale/en.js
@@ -376,9 +376,10 @@ Oskari.registerLocalization(
                 "not_supported_wfs_maplayer": "Analysis works currently only with WFS 1.0.0 and 1.1.0. Unfortunately analysis does not work yet with the API version you have selected."
             },
             "infos": {
-                "title": "Too many attributes",
+                "title": "Attributes",
                 "layer": "Features on the layer",
-                "over10": "have over ten attributes. Please select at most ten attributes into the analysis result. The attributes you can select in the parameters."
+                "over10": "have over ten attributes. Please select at most ten attributes into the analysis result. The attributes you can select in the parameters.",
+                "userlayer": "The attribute data from own datasets cannot be used in analyses. Geometries can still be used (buffer, union, clip)."
             },
             "aggregatePopup": {
                 "title": "Analysis results",

--- a/bundles/analysis/analyse/resources/locale/fi.js
+++ b/bundles/analysis/analyse/resources/locale/fi.js
@@ -376,9 +376,10 @@ Oskari.registerLocalization(
                 "not_supported_wfs_maplayer" : "Analyysi toimii tällä hetkellä vain WFS:n versioilla 1.0.0 ja 1.1.0. Valitettavasti analyysi ei vielä toimi nyt käyttämälläsi rajapintatyypillä."
             },
             "infos": {
-                "title": "Liikaa ominaisuustietoja",
+                "title": "Ominaisuustiedot",
                 "layer": "Tason",
-                "over10": "kohteilla on yli 10 ominaisuustietoa. Valitse analyysin lopputulokseen enintään 10 ominaisuustietoa. Valinnan voit tehdä parametrien valinnan yhteydessä."
+                "over10": "kohteilla on yli 10 ominaisuustietoa. Valitse analyysin lopputulokseen enintään 10 ominaisuustietoa. Valinnan voit tehdä parametrien valinnan yhteydessä.",
+                "userlayer": "Omien aineistojen ominaisuustietoja ei voida käyttää analyyseissä, kohteiden geometrioilla voi kuitenkin tehdä analyysejä (vyöhyke, yhdiste, leikkaus)."
             },
             "aggregatePopup": {
                 "title": "Analyysin tulokset",

--- a/bundles/analysis/analyse/resources/locale/sv.js
+++ b/bundles/analysis/analyse/resources/locale/sv.js
@@ -376,9 +376,10 @@ Oskari.registerLocalization(
                 "not_supported_wfs_maplayer": "Analysen är för tillfället endast tillgänglig med WFS-versioner 1.0.0 och 1.1.0. Tyvärr är gränssnittstypen du använder inte ännu stödd i tjänsten."
             },
             "infos": {
-                "title": "För många attributer",
+                "title": "Attributer",
                 "layer": "Analyslager",
-                "over10": "har över 10 attribut. Välj högst 10 attribut för analys. Du hittar en lista av attribut i meny \"Parameter\" när du har valt en analysmetod."
+                "over10": "har över 10 attribut. Välj högst 10 attribut för analys. Du hittar en lista av attribut i meny \"Parameter\" när du har valt en analysmetod.",
+                "userlayer": "De egna datamängdernas attributer kan inte användas i analysfunktionen. Objekternas geometrier (zon, union, snitt) kan dock användas."
             },
             "aggregatePopup": {
                 "title": "Analys resultat",

--- a/bundles/analysis/analyse/view/StartAnalyse.ol.js
+++ b/bundles/analysis/analyse/view/StartAnalyse.ol.js
@@ -1106,6 +1106,8 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
             me.refreshExtraParameters();
             me._checkParamsSelection();
             me._checkMethodSelection();
+            // Show the possible warnings for selected layer.
+            me.showInfos();
         },
         /**
          * @private @method _determineAnalysisWFSLayer
@@ -3326,8 +3328,6 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
 
         show: function () {
             this.mainPanel.show();
-            // Show the possible warnings for selected layer.
-            this.showInfos();
         },
 
         setEnabled: function (enabled) {


### PR DESCRIPTION
Use instance wfsLayerHasUnsupportedVersion for StartAnalyse.ol _eligibleForAnalyse and remove _unsupportedWfsLayerVersion from StartAnalyse.ol. Move showInfos() from render() to _addAnalyseData to show infos also when new layer is added or analyse is started again. Add attribute info and disable attribute selection for userlayer.