### PR TITLE
Analysis properties handling

### DIFF
--- a/bundles/analysis/analyse/service/AnalyseService.js
+++ b/bundles/analysis/analyse/service/AnalyseService.js
@@ -181,7 +181,7 @@ Oskari.clazz.define(
          *
          */
         _getWFSLayerPropertiesAndTypes: function (layer_id, success2, failure) {
-            var url = Oskari.urls.getRoute('GetWFSDescribeFeature') + '&simple=true&layer_id=' + layer_id;
+            var url = Oskari.urls.getRoute('GetWFSLayerFields') + '&layer_id=' + layer_id;
             jQuery.ajax({
                 type: 'GET',
                 dataType: 'json',
@@ -202,15 +202,15 @@ Oskari.clazz.define(
          *
          *
          */
-        loadWFSLayerPropertiesAndTypes: function (layer_id) {
+        loadWFSLayerPropertiesAndTypes: function (layerId) {
             var me = this;
 
             // Request analyis layers via the backend
-            me._getWFSLayerPropertiesAndTypes(layer_id,
+            me._getWFSLayerPropertiesAndTypes(layerId,
                 // Success callback
                 function (response) {
                     if (response) {
-                        me._handleWFSLayerPropertiesAndTypesResponse(response);
+                        me._handleWFSLayerPropertiesAndTypesResponse(layerId, response);
                     }
                 },
                 // Error callback
@@ -226,18 +226,10 @@ Oskari.clazz.define(
          * @param {JSON} propertyJson properties and property types of WFS layer JSON returned by server.
          *
          */
-        _handleWFSLayerPropertiesAndTypesResponse: function (propertyJson) {
-            var me = this,
-                layer = null;
-
-            if (propertyJson.layer_id) {
-                layer = me.instance.getSandbox().findMapLayerFromSelectedMapLayers(propertyJson.layer_id);
-            }
+        _handleWFSLayerPropertiesAndTypesResponse: function (layerId, propertyJson) {
+            const layer = this.instance.getSandbox().findMapLayerFromSelectedMapLayers(layerId);
             if (layer) {
-                layer.setPropertyTypes(propertyJson.propertyTypes);
-                if (propertyJson.wps_params) {
-                    layer.setWpsLayerParams(propertyJson.wps_params);
-                }
+                layer.setPropertyTypes(propertyJson.types);
             }
         }
     }, {

--- a/bundles/mapping/mapanalysis/domain/AnalysisLayer.js
+++ b/bundles/mapping/mapanalysis/domain/AnalysisLayer.js
@@ -10,6 +10,9 @@ export class AnalysisLayer extends WFSLayer {
         /* Layer Type */
         this._layerType = 'analysislayer'; // 'ANALYSIS';
         this._metaType = 'ANALYSIS';
+        this._wpsUrl = null;
+        this._wpsName = null;
+        this._wpsLayerId = null;
     }
     /**
      * Sets the WPS url where the layer images are fetched from
@@ -57,23 +60,6 @@ export class AnalysisLayer extends WFSLayer {
      */
     getWpsLayerId () {
         return this._wpsLayerId;
-    }
-    /**
-     * @method setOverrideSld
-     * @param {String} override_sld override sld style name in geoserver
-     */
-    setOverrideSld (override_sld) {
-        this._override_sld = override_sld;
-    }
-    /**
-     * @method  getOverrideSld override sld style name in geoserver
-     * @return {String}
-     */
-    getOverrideSld () {
-        return this._override_sld;
-    }
-    isFilterSupported () {
-        return true;
     }
 };
 

--- a/bundles/mapping/mapanalysis/domain/AnalysisLayerModelBuilder.js
+++ b/bundles/mapping/mapanalysis/domain/AnalysisLayerModelBuilder.js
@@ -70,15 +70,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapanalysis.domain.AnalysisLayer
         // call parent parseLayerData
         this.wfsBuilder.parseLayerData(layer, mapLayerJson, maplayerService);
 
-        if (mapLayerJson.fields) {
-            layer.setFields(mapLayerJson.fields);
-        }
-        if (mapLayerJson.locales) {
-            layer.setLocales(mapLayerJson.locales);
-        }
-        if (mapLayerJson.name) {
-            layer.setName(mapLayerJson.name);
-        }
         if (mapLayerJson.wpsName) {
             layer.setWpsName(mapLayerJson.wpsName);
         }
@@ -87,12 +78,6 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapanalysis.domain.AnalysisLayer
         }
         if (mapLayerJson.wpsLayerId) {
             layer.setWpsLayerId(mapLayerJson.wpsLayerId);
-        }
-        if (mapLayerJson.wps_params) {
-            layer.setWpsLayerParams(mapLayerJson.wps_params);
-        }
-        if (mapLayerJson.override_sld) {
-            layer.setOverrideSld(mapLayerJson.override_sld);
         }
         if (loclayer.organization) {
             layer.setOrganizationName(loclayer.organization);


### PR DESCRIPTION
Remove layer.getFields and use getPropertyTypes. Use GetWFSLayerFields instead of GetWFSDescribeFeature action route to get feature property names and types ('numeric' type changed to 'number').