### PR TITLE
Analysis layer add locale

### DIFF
--- a/bundles/mapping/mapanalysis/domain/AnalysisLayer.js
+++ b/bundles/mapping/mapanalysis/domain/AnalysisLayer.js
@@ -10,9 +10,31 @@ export class AnalysisLayer extends WFSLayer {
         /* Layer Type */
         this._layerType = 'analysislayer'; // 'ANALYSIS';
         this._metaType = 'ANALYSIS';
+        this._locale = {};
         this._wpsUrl = null;
         this._wpsName = null;
         this._wpsLayerId = null;
+    }
+    // override to get name from locale
+    getName (lang = Oskari.getLang()) {
+        const locale = this.getLocale();
+        let { name } = locale[lang] || {};
+        if (!name) {
+            const defaultLocale = locale[Oskari.getDefaultLanguage()] || {};
+            name = defaultLocale.name;
+        }
+        if (name) {
+            return Oskari.util.sanitize(name);
+        }
+        return '';
+    }
+
+    getLocale () {
+        return this._locale;
+    }
+
+    setLocale (locale) {
+        this._locale = locale;
     }
     /**
      * Sets the WPS url where the layer images are fetched from

--- a/bundles/mapping/mapanalysis/domain/AnalysisLayerModelBuilder.js
+++ b/bundles/mapping/mapanalysis/domain/AnalysisLayerModelBuilder.js
@@ -76,9 +76,12 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapanalysis.domain.AnalysisLayer
         if (loclayer.organization) {
             layer.setOrganizationName(loclayer.organization);
         }
+        if (mapLayerJson.locale) {
+            layer.setLocale(mapLayerJson.locale);
+        }
         if (!this.groupId) {
             // negative value for group id means that admin isn't presented with tools for it
-            this.groupId = -1 * Oskari.getSeq('usergeneratedGroup').nextVal();
+            this.groupId = -10 * Oskari.getSeq('usergeneratedGroup').nextVal();
             // initialize the group these layers will be in:
             const mapLayerGroup = maplayerService.getAllLayerGroups(this.groupId);
             if (!mapLayerGroup) {


### PR DESCRIPTION
Override getName to use locale. This allows backend userdata layer json formatter to remove adding names to maplayer json. As myplaces and userlayer uses react forms and localizationcomponent Analysis is still using only one name input and setting name  in locale[defaultLang]name in backend.