### PR TITLE
Analysis style editor

### DIFF
--- a/bundles/analysis/analyse/resources/locale/en.js
+++ b/bundles/analysis/analyse/resources/locale/en.js
@@ -332,10 +332,9 @@ Oskari.registerLocalization(
             },
             "output": {
                 "label": "Feature style",
-                "color_label": "Select style",
-                "colorset_tooltip": "Select style for points, lines and regions.",
                 "tooltip": "Select a style for points, lines and areas in the result.",
-                "random_color_label": "Random colours",
+                "editStyle": "Edit",
+                "randomColor": "Random colours",
                 "defaultStyle": "Default style"
             },
             "buttons": {

--- a/bundles/analysis/analyse/resources/locale/en.js
+++ b/bundles/analysis/analyse/resources/locale/en.js
@@ -335,7 +335,8 @@ Oskari.registerLocalization(
                 "color_label": "Select style",
                 "colorset_tooltip": "Select style for points, lines and regions.",
                 "tooltip": "Select a style for points, lines and areas in the result.",
-                "random_color_label": "Random colours"
+                "random_color_label": "Random colours",
+                "defaultStyle": "Default style"
             },
             "buttons": {
                 "save": "Save and finish",

--- a/bundles/analysis/analyse/resources/locale/fi.js
+++ b/bundles/analysis/analyse/resources/locale/fi.js
@@ -332,10 +332,9 @@ Oskari.registerLocalization(
             },
             "output": {
                 "label": "Kohteiden esitystapa",
-                "color_label": "Valitse tyyli",
-                "colorset_tooltip": "Valitse tyyli pisteille, viivoille ja alueille.",
                 "tooltip": "Määrittele esitystapa lopputuloksessa näytettäville pisteille, viivoille ja alueille.",
-                "random_color_label": "Satunnaiset värit",
+                "editStyle": "Muokkaa",
+                "randomColor": "Satunnaiset värit",
                 "defaultStyle": "Oletustyyli"
             },
             "buttons": {

--- a/bundles/analysis/analyse/resources/locale/fi.js
+++ b/bundles/analysis/analyse/resources/locale/fi.js
@@ -335,7 +335,8 @@ Oskari.registerLocalization(
                 "color_label": "Valitse tyyli",
                 "colorset_tooltip": "Valitse tyyli pisteille, viivoille ja alueille.",
                 "tooltip": "Määrittele esitystapa lopputuloksessa näytettäville pisteille, viivoille ja alueille.",
-                "random_color_label": "Satunnaiset värit"
+                "random_color_label": "Satunnaiset värit",
+                "defaultStyle": "Oletustyyli"
             },
             "buttons": {
                 "save": "Tallenna ja lopeta",

--- a/bundles/analysis/analyse/resources/locale/sv.js
+++ b/bundles/analysis/analyse/resources/locale/sv.js
@@ -335,7 +335,8 @@ Oskari.registerLocalization(
                 "color_label": "Välj stil:",
                 "colorset_tooltip": "Välj stil för punkter, linjer och område.",
                 "tooltip": "Välj en passande stil för punkter, linjer och område.",
-                "random_color_label": "Slumpmässiga färg"
+                "random_color_label": "Slumpmässiga färg",
+                "defaultStyle": "Förvalt utseende"
             },
             "buttons": {
                 "save": "Lagra och sluta",

--- a/bundles/analysis/analyse/resources/locale/sv.js
+++ b/bundles/analysis/analyse/resources/locale/sv.js
@@ -332,10 +332,9 @@ Oskari.registerLocalization(
             },
             "output": {
                 "label": "Utseende",
-                "color_label": "Välj stil:",
-                "colorset_tooltip": "Välj stil för punkter, linjer och område.",
                 "tooltip": "Välj en passande stil för punkter, linjer och område.",
-                "random_color_label": "Slumpmässiga färg",
+                "editStyle": "Redigera",
+                "randomColor": "Slumpmässiga färg",
                 "defaultStyle": "Förvalt utseende"
             },
             "buttons": {

--- a/bundles/analysis/analyse/view/StartAnalyse.ol.js
+++ b/bundles/analysis/analyse/view/StartAnalyse.ol.js
@@ -763,12 +763,11 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
             panel.getHeader().append(tooltipCont);
 
             const button = Oskari.clazz.create('Oskari.userinterface.component.Button');
-            button.setTitle(this.loc.output.color_label);
+            button.setTitle(this.loc.output.editStyle);
             button.setPrimary(true);
             button.setHandler(() => {
                 this.openStyleEditor();
             });
-
             panel.setContent(button.getElement());
 
             return panel;
@@ -863,20 +862,28 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
          *
          * @return {Object}
          */
-        getStyleValues: function () {
-            return this._ownStyle || this.getRandomizedStyle();
+        getStyleValues: function (pick) {
+            if (!this._ownStyle) {
+                this._ownStyle = this.getRandomizedStyle();
+            }
+            const style = this._ownStyle;
+            if (pick) {
+                this._ownStyle = null;
+            }
+            return style;
         },
         openStyleEditor : function () {
             if (this._popupControls) {
                 return;
             }
-            const style = this.getRandomizedStyle();
+            const style = this.getStyleValues();
             const onSave = style => {
                 this._ownStyle = style;
                 this.closeStyleEditor();
             };
+            const getRandom = () => this.getRandomizedStyle();
             const onClose = () => this.closeStyleEditor();
-            this._popupControls = showStyleEditor(style, onSave, onClose)
+            this._popupControls = showStyleEditor(style, getRandom, onSave, onClose)
         },
         closeStyleEditor: function () {
             if (this._popupControls) {
@@ -2312,7 +2319,7 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
             var selections = this._getMethodSelections(layer, defaults);
 
             // Styles
-            selections.style = this.getStyleValues();
+            selections.style = this.getStyleValues(true);
             // Bbox
             selections.bbox = this.instance.getSandbox().getMap().getBbox();
 

--- a/bundles/analysis/analyse/view/StartAnalyse.ol.js
+++ b/bundles/analysis/analyse/view/StartAnalyse.ol.js
@@ -1,4 +1,6 @@
 import olFormatGeoJSON from 'ol/format/GeoJSON';
+import { COLORS, FILL_COLORS, DEFAULT_STYLE } from './constants';
+import { showStyleEditor } from './StyleForm';
 /**
  * @class Oskari.analysis.bundle.analyse.view.StartAnalyse
  * Request the analyse params and layers and triggers analyse actions
@@ -79,6 +81,9 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
         me.contentOptions = {};
         me.intersectOptions = {};
         me.unionOptions = {};
+
+        me._ownStyle = null;
+        me._popupControls = null;
 
         me.accordion = null;
         me.mainPanel = null;
@@ -179,10 +184,6 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
             title_name:
                 '<div class="analyse_title_name analyse_settings_cont">' +
                 '  <input class="settings_name_field" type="text" />' +
-                '</div>',
-            title_color:
-                '<div class="analyse_title_colcont analyse_output_cont">' +
-                '  <div class="output_color_label"></div>' +
                 '</div>',
             title_columns:
                 '<div class="analyse_title_columns analyse_output_cont">' +
@@ -752,46 +753,23 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
          * @return {jQuery} Returns the created panel
          */
         _createOutputPanel: function () {
-            var me = this,
-                panel = Oskari.clazz.create(
-                    'Oskari.userinterface.component.AccordionPanel'
-                ),
-                headerPanel = panel.getHeader(),
-                colorRandomizer = me.template.checkboxToolOptíon.clone(),
-                colorTitle = me.template.title_color.clone(),
-                contentPanel = panel.getContainer(),
-                tooltipCont = me.template.help.clone(),
-                visualizationForm = Oskari.clazz.create(
-                    'Oskari.userinterface.component.VisualizationForm', {saveCallback: function () {
-                        me.ownStyleSaved();
-                    }}
-                );
-
-            colorRandomizer.find('input')
-                .addClass('analyse_randomize_colors')
-                .attr('name', 'randomize_colors')
-                .attr('id', 'analyse_randomize_colors_input');
-
-            panel.setTitle(me.loc.output.label);
+            const panel = Oskari.clazz.create('Oskari.userinterface.component.AccordionPanel');
+            panel.setTitle(this.loc.output.label);
 
             // tooltip
-            tooltipCont.attr('title', me.loc.output.tooltip);
+            const tooltipCont = this.template.help.clone();
+            tooltipCont.attr('title', this.loc.output.tooltip);
             tooltipCont.addClass('header-icon-info');
-            headerPanel.append(tooltipCont);
+            panel.getHeader().append(tooltipCont);
 
-            // title
-            colorTitle.find('.output_color_label').html(me.loc.output.color_label);
-            contentPanel.append(colorTitle);
+            const button = Oskari.clazz.create('Oskari.userinterface.component.Button');
+            button.setTitle(this.loc.output.color_label);
+            button.setPrimary(true);
+            button.setHandler(() => {
+                this.openStyleEditor();
+            });
 
-            // Create random color picker checkbox
-            colorRandomizer.find('input[name=randomize_colors]').prop('checked', true);
-            colorRandomizer.find('label').addClass('params_checklabel').find('span').html(
-                me.loc.output.random_color_label
-            );
-            contentPanel.append(colorRandomizer);
-
-            me.visualizationForm = visualizationForm;
-            contentPanel.append(me.visualizationForm.getForm());
+            panel.setContent(button.getElement());
 
             return panel;
         },
@@ -886,10 +864,38 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
          * @return {Object}
          */
         getStyleValues: function () {
-            // Sets random color values for visualization form
-            // if the checkbox is checked.
-            this.randomizeColors();
-            return this.visualizationForm.getOskariStyle();
+            return this._ownStyle || this.getRandomizedStyle();
+        },
+        openStyleEditor : function () {
+            if (this._popupControls) {
+                return;
+            }
+            const style = this.getRandomizedStyle();
+            const onSave = style => {
+                this._ownStyle = style;
+                this.closeStyleEditor();
+            };
+            const onClose = () => this.closeStyleEditor();
+            this._popupControls = showStyleEditor(style, onSave, onClose)
+        },
+        closeStyleEditor: function () {
+            if (this._popupControls) {
+                this._popupControls.close();
+            }
+            this._popupControls = null;
+        },
+        getRandomizedStyle: function () {
+            const index = Math.floor(Math.random() * (COLORS.length - 1))
+            const color = COLORS[index];
+            const style = {
+                fill: { color: FILL_COLORS[index] },
+                image : { fill: { color } },
+                stroke: {
+                    color,
+                    area : { color }
+                }
+            };
+            return jQuery.extend(true, {}, DEFAULT_STYLE, style)
         },
 
         /**
@@ -3174,58 +3180,6 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
                 .find('#oskari_analyse_select')
                 .prop('checked', true)
                 .trigger('change');
-        },
-
-        /**
-         * @method randomColors
-         * Change default colors for analyse in random range order
-         *
-         *
-         */
-        randomizeColors: function () {
-            if (!this.mainPanel.find('input[name=randomize_colors]').is(':checked')) {
-                return;
-            }
-
-            if (this.colorCount === undefined || this.colorCount === 16) {
-                this.colorCount = 0;
-            } else {
-                this.colorCount += 1;
-            }
-
-            var line_point_border_colors = [
-                    '#e31a1c', '#2171b5', '#238b45', '#88419d',
-                    '#2b8cbe', '#238b45', '#d94801', '#d7301f',
-                    '#0570b0', '#02818a', '#ce1256', '#6a51a3',
-                    '#ae017e', '#cb181d', '#238443', '#225ea8',
-                    '#cc4c02'
-                ],
-                fill_colors = [
-                    '#fd8d3c', '#6baed6', '#66c2a4', '#8c96c6',
-                    '#7bccc4', '#74c476', '#fd8d3c', '#fc8d59',
-                    '#74a9cf', '#67a9cf', '#df65b0', '#9e9ac8',
-                    '#f768a1', '#fb6a4a', '#78c679', '#41b6c4',
-                    '#fe9929'
-                ],
-                values = {
-                    point: {
-                        color: line_point_border_colors[this.colorCount]
-                    },
-                    line: {
-                        color: line_point_border_colors[this.colorCount]
-                    },
-                    area: {
-                        lineColor: line_point_border_colors[this.colorCount],
-                        fillColor: fill_colors[this.colorCount]
-                    }
-                };
-
-            if (this.visualizationForm) {
-                this.visualizationForm.setValues(values);
-            }
-        },
-        ownStyleSaved: function () {
-            this.mainPanel.find('input[name=randomize_colors]').prop('checked', false);
         },
 
         /**

--- a/bundles/analysis/analyse/view/StyleForm.jsx
+++ b/bundles/analysis/analyse/view/StyleForm.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Message, Button } from 'oskari-ui';
+import { SecondaryButton, PrimaryButton, ButtonContainer } from 'oskari-ui/components/buttons';
+import { showPopup } from 'oskari-ui/components/window';
+import { StyleEditor } from 'oskari-ui/components/StyleEditor';
+import { BUNDLE_KEY, DEFAULT_STYLE } from './constants';
+
+const Content = styled.div`
+    padding: 24px;
+    width: 500px;
+`;
+
+const getMessage = key => <Message messageKey={ `AnalyseView.output.${key}` } bundleKey={BUNDLE_KEY} />;
+
+const StyleForm = ({ style: initStyle, onSave, onCancel }) => {
+    const [style, setStyle] = useState(initStyle);
+    return (
+        <Content>
+            <StyleEditor
+                oskariStyle={ style }
+                onChange={ setStyle }
+            />
+            <ButtonContainer>
+                <Button onClick={() => setStyle(DEFAULT_STYLE)}>{getMessage('defaultStyle')}</Button>
+                <SecondaryButton type='cancel' onClick={onCancel}/>
+                <PrimaryButton type='save' onClick={() => onSave(style) }/>
+            </ButtonContainer>
+        </Content>
+    );
+};
+
+StyleForm.propTypes = {
+    onSave: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    style: PropTypes.object.isRequired
+};
+
+export const showStyleEditor = (style, onSave, onClose) => {
+    return showPopup(
+        getMessage('label'),
+        (<StyleForm style={style} onSave={onSave} onCancel={onClose}/>),
+        onClose,
+        { id: BUNDLE_KEY }
+    );
+};

--- a/bundles/analysis/analyse/view/StyleForm.jsx
+++ b/bundles/analysis/analyse/view/StyleForm.jsx
@@ -14,7 +14,7 @@ const Content = styled.div`
 
 const getMessage = key => <Message messageKey={ `AnalyseView.output.${key}` } bundleKey={BUNDLE_KEY} />;
 
-const StyleForm = ({ style: initStyle, onSave, onCancel }) => {
+const StyleForm = ({ style: initStyle, onSave, onCancel, getRandom }) => {
     const [style, setStyle] = useState(initStyle);
     return (
         <Content>
@@ -23,6 +23,7 @@ const StyleForm = ({ style: initStyle, onSave, onCancel }) => {
                 onChange={ setStyle }
             />
             <ButtonContainer>
+                <Button onClick={() => setStyle(getRandom())}>{getMessage('randomColor')}</Button>
                 <Button onClick={() => setStyle(DEFAULT_STYLE)}>{getMessage('defaultStyle')}</Button>
                 <SecondaryButton type='cancel' onClick={onCancel}/>
                 <PrimaryButton type='save' onClick={() => onSave(style) }/>
@@ -34,13 +35,14 @@ const StyleForm = ({ style: initStyle, onSave, onCancel }) => {
 StyleForm.propTypes = {
     onSave: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
+    getRandom: PropTypes.func.isRequired,
     style: PropTypes.object.isRequired
 };
 
-export const showStyleEditor = (style, onSave, onClose) => {
+export const showStyleEditor = (style, getRandom, onSave, onClose) => {
     return showPopup(
         getMessage('label'),
-        (<StyleForm style={style} onSave={onSave} onCancel={onClose}/>),
+        (<StyleForm style={style} getRandom={getRandom} onSave={onSave} onCancel={onClose}/>),
         onClose,
         { id: BUNDLE_KEY }
     );

--- a/bundles/analysis/analyse/view/constants.js
+++ b/bundles/analysis/analyse/view/constants.js
@@ -1,0 +1,18 @@
+import { OSKARI_BLANK_STYLE } from 'oskari-ui/components/StyleEditor/index';
+export const DEFAULT_STYLE = { ...OSKARI_BLANK_STYLE };
+export const BUNDLE_KEY = 'Analyse';
+// Both color arrays have to be equal length
+export const COLORS = [
+    '#e31a1c', '#2171b5', '#238b45', '#88419d',
+    '#2b8cbe', '#238b45', '#d94801', '#d7301f',
+    '#0570b0', '#02818a', '#ce1256', '#6a51a3',
+    '#ae017e', '#cb181d', '#238443', '#225ea8',
+    '#cc4c02'
+];
+export const FILL_COLORS = [
+    '#fd8d3c', '#6baed6', '#66c2a4', '#8c96c6',
+    '#7bccc4', '#74c476', '#fd8d3c', '#fc8d59',
+    '#74a9cf', '#67a9cf', '#df65b0', '#9e9ac8',
+    '#f768a1', '#fb6a4a', '#78c679', '#41b6c4',
+    '#fe9929'
+];

--- a/packages/analysis/ol/analyse/bundle.js
+++ b/packages/analysis/ol/analyse/bundle.js
@@ -69,21 +69,6 @@ Oskari.clazz.define("Oskari.analysis.bundle.analyse.AnalyseBundle", function() {
         },{
             "type" : "text/css",
             "src" : "../../../../bundles/analysis/analyse/resources/scss/style.scss"
-        }, {
-            "type": "text/javascript",
-            "src": "oskari-frontend/bundles/framework/divmanazer/component/VisualizationForm.js"
-        }, {
-            "type": "text/javascript",
-            "src": "oskari-frontend/bundles/framework/divmanazer/component/visualization-form/AreaForm.js"
-        }, {
-            "type": "text/javascript",
-            "src": "oskari-frontend/bundles/framework/divmanazer/component/visualization-form/LineForm.js"
-        }, {
-            "type": "text/javascript",
-            "src": "oskari-frontend/bundles/framework/divmanazer/component/visualization-form/DotForm.js"
-        }, {
-            "type": "text/css",
-            "src": "oskari-frontend/bundles/framework/divmanazer/resources/scss/visualizationform.scss"
         }],
 
         "locales" : [{


### PR DESCRIPTION
Add StyleForm. StartAnalyse is so complicated that doesn't find the easy way to initialize and reset color on start/finish. Now gathering values uses pick which removes ownStyle to get new randomized color for next analysis. Added default style and randomize buttons to style editor and removed check box.