### PR TITLE
Change layer group name for analysis

### DIFF
--- a/bundles/mapping/mapanalysis/domain/AnalysisLayerModelBuilder.js
+++ b/bundles/mapping/mapanalysis/domain/AnalysisLayerModelBuilder.js
@@ -87,9 +87,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapanalysis.domain.AnalysisLayer
             if (!mapLayerGroup) {
                 const group = {
                     id: this.groupId,
-                    name: {
-                        [Oskari.getLang()]: loclayer.inspire
-                    }
+                    name: loclayer.inspire
                 };
                 maplayerService.addLayerGroup(Oskari.clazz.create('Oskari.mapframework.domain.MaplayerGroup', group));
             }


### PR DESCRIPTION
Locale object for group name is no longer supported by layerlist (admin functionalities should fetch other languages separately for editing). Related to: https://github.com/oskariorg/oskari-frontend/pull/1830