### PR TITLE
Analysis set styles from options

### DIFF
--- a/bundles/mapping/mapanalysis/domain/AnalysisLayerModelBuilder.js
+++ b/bundles/mapping/mapanalysis/domain/AnalysisLayerModelBuilder.js
@@ -64,6 +64,7 @@ Oskari.clazz.define('Oskari.mapframework.bundle.mapanalysis.domain.AnalysisLayer
 
         // call parent parseLayerData
         this.wfsBuilder.parseLayerData(layer, mapLayerJson, maplayerService);
+        layer.setStylesFromOptions(mapLayerJson.options);
 
         if (mapLayerJson.wpsName) {
             layer.setWpsName(mapLayerJson.wpsName);


### PR DESCRIPTION
WFS model builder (or abstract vector layer) doesn't set styles from options (uses DescribeLayer). Set styles from options for analysis layer.

https://github.com/oskariorg/oskari-frontend/blob/develop/bundles/mapping/mapuserlayers/domain/UserLayerModelBuilder.js#L28