### PR TITLE
Content-editor: handling for unrecognized geometry type

### DIFF
--- a/bundles/tampere/content-editor/resources/locale/en.js
+++ b/bundles/tampere/content-editor/resources/locale/en.js
@@ -15,8 +15,9 @@ Oskari.registerLocalization(
             },
             "newTitle": "New features",
             "geometrylist": {
-                "title": "Geomerty",
+                "title": "Geometry",
                 "empty": "Draw a geometry on the map",
+                "notRecognized": "Geometry type ({type}) not recognized. Allowing all types to be added. Make sure the interface is ok with this.",
                 "editing": "Draw on the map",
                 "Point": "Point",
                 "LineString": "Line",

--- a/bundles/tampere/content-editor/resources/locale/fi.js
+++ b/bundles/tampere/content-editor/resources/locale/fi.js
@@ -17,6 +17,7 @@ Oskari.registerLocalization(
             "geometrylist": {
                 "title": "Geometria",
                 "empty": "Merkitse geometria kartalle",
+                "notRecognized": "Geometrian tyyppiä ({type}) ei tunnistettu. Kaikki piirtomuodot sallitaan, mutta varmista rajapinnan tukevan näitä ennen tallennusta.",
                 "editing": "Tee merkintä kartalle",
                 "Point": "Piste",
                 "LineString": "Viiva",

--- a/bundles/tampere/content-editor/view/FeatureForm.jsx
+++ b/bundles/tampere/content-editor/view/FeatureForm.jsx
@@ -32,6 +32,9 @@ const getFieldForType = (name, type, value, onUpdate) => {
 }
 
 const getDecorated = ({ name, type, value, originalValue, isNew, onUpdate }) => {
+    if (type === 'geometry') {
+        return null;
+    }
     const hasChanged = !isNew && originalValue !== value;
     let labelForOriginal = originalValue;
     if (!labelForOriginal) {

--- a/bundles/tampere/content-editor/view/GeometryPanel.jsx
+++ b/bundles/tampere/content-editor/view/GeometryPanel.jsx
@@ -9,8 +9,12 @@ export const StyledList = styled('ul')`
     list-style-type: none;
 `;
 const StyledAlert = styled(Alert)`
-margin-top: 5px;
-margin-bottom: 5px;
+    margin-top: 5px;
+    margin-bottom: 5px;
+`;
+
+const EditButton = styled(Button)`
+    margin-left: 10px;
 `;
 export const StyledListItem = styled('li')`
     padding: 5px;
@@ -100,9 +104,9 @@ export const GeometryPanel = ({ type = '', feature = {}, original = {}, startDra
             <StyledSpace>
                 <StyledContainer>
                     <Message messageKey="ContentEditorView.geometrylist.title" />
-                    <Button onClick={() => startDrawing(type)}>
+                    <EditButton onClick={() => startDrawing(feature.geometry?.type || type)}>
                         <Message messageKey="ContentEditorView.tools.geometryEdit" />
-                    </Button>
+                    </EditButton>
                 </StyledContainer>
                 <br />
                 {geometryChanged && <StyledContainer>

--- a/bundles/tampere/content-editor/view/GeometryPanel.jsx
+++ b/bundles/tampere/content-editor/view/GeometryPanel.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Message, Button, Space } from 'oskari-ui';
+import { Alert, Message, Button, Space } from 'oskari-ui';
 import { StyledSpace, StyledContainer, StyledModIndicator } from './styled';
 import styled from 'styled-components';
 
@@ -8,7 +8,10 @@ export const StyledList = styled('ul')`
     width: 100%:
     list-style-type: none;
 `;
-
+const StyledAlert = styled(Alert)`
+margin-top: 5px;
+margin-bottom: 5px;
+`;
 export const StyledListItem = styled('li')`
     padding: 5px;
     border: 1px solid gray;
@@ -44,30 +47,40 @@ const geometryMatch = (current = {}, original = {}) => {
 export const GeometryPanel = ({ type = '', feature = {}, original = {}, startDrawing, updateGeometry}) => {
     const isMulti = type.includes('Multi');
     const isGeomBtnShown = (btnType) => type.includes(btnType);
+    const isPoint = isGeomBtnShown('Point');
+    const isLine = isGeomBtnShown('LineString')
+    const isPolygon = isGeomBtnShown('Polygon');
+    const isRecognized = isPoint || isLine || isPolygon;
     useEffect(() => {
         initLayerOnMap();
         return cleanup;
     });
     if (!feature.geometry) {
-        return (<Space>
-            <Message messageKey="ContentEditorView.geometrylist.empty" />
-            
-            { isGeomBtnShown('Point') &&
-                <Button onClick={() => startDrawing('Point')}>
-                    <Message messageKey="ContentEditorView.tools.point" />
-                </Button>
-            }
-            { isGeomBtnShown('LineString') &&
-                <Button onClick={() => startDrawing('LineString')}>
-                    <Message messageKey="ContentEditorView.tools.line" />
-                </Button>
-            }
-            { isGeomBtnShown('Polygon') &&
-                <Button onClick={() => startDrawing('Polygon')}>
-                    <Message messageKey="ContentEditorView.tools.area" />
-                </Button>
-            }
-        </Space>);
+        return (
+            <React.Fragment>
+                <StyledSpace>
+                    <Message messageKey="ContentEditorView.geometrylist.empty" />
+                </StyledSpace>
+                { !isRecognized &&
+                    <StyledAlert message={<Message messageKey="ContentEditorView.geometrylist.notRecognized" messageArgs={{type}}/>} /> }
+                <Space>
+                    { (!isRecognized || isPoint) &&
+                        <Button onClick={() => startDrawing('Point')}>
+                            <Message messageKey="ContentEditorView.tools.point" />
+                        </Button>
+                    }
+                    { (!isRecognized || isLine) &&
+                        <Button onClick={() => startDrawing('LineString')}>
+                            <Message messageKey="ContentEditorView.tools.line" />
+                        </Button>
+                    }
+                    { (!isRecognized || isPolygon) &&
+                        <Button onClick={() => startDrawing('Polygon')}>
+                            <Message messageKey="ContentEditorView.tools.area" />
+                        </Button>
+                    }
+                </Space>
+            </React.Fragment>);
     }
     // has geometry
     const isNew = !feature.id;

--- a/bundles/tampere/content-editor/view/Helper.js
+++ b/bundles/tampere/content-editor/view/Helper.js
@@ -22,6 +22,8 @@ const GEOM_TYPE_MAPPING = {
 const detectGeometryType= (type) => GEOM_TYPE_MAPPING[type] || GEOM_TYPE_MAPPING['gml:' + type];
 
 const describeLayer = (id) => {
+    // TODO: change to use DescribeLayer on 2.11+
+    // return fetch(Oskari.urls.getRoute('DescribeLayer', { id: id }), {
     return fetch(Oskari.urls.getRoute('GetWFSLayerFields', { layer_id: id }), {
         method: 'GET',
         headers: {

--- a/bundles/tampere/content-editor/view/InfoPanel.jsx
+++ b/bundles/tampere/content-editor/view/InfoPanel.jsx
@@ -5,14 +5,21 @@ import { Card } from 'oskari-ui/components/Card';
 import styled from 'styled-components';
 
 const Paragraph = styled('p')``;
+const StyledCard = styled(Card)`
+.ant-card-head-title {
+    white-space: normal;
+}
+`;
+
+
 export const InfoPanel = ({ layer = {}, startNewFeature, onClose}) => {
     return (
         <React.Fragment>
             <Message messageKey="ContentEditorView.info.layerLabel" />:
             <Space direction="vertical">
-                <Card title={layer.name}>
+                <StyledCard title={layer.name}>
                     <Message messageKey="ContentEditorView.info.featureModifyInfo" LabelComponent={Paragraph}/>
-                </Card>
+                </StyledCard>
                 
                 <Space>
                     <Button onClick={onClose}>


### PR DESCRIPTION
If the geometry type cannot be detected as `Point`, `LineString` or `Polygon` (can be for example `GeometryPropertyType`), allow all geometry drawing types but show a warning:
![image](https://github.com/oskariorg/oskari-frontend-contrib/assets/2210335/1bd2c591-0dc8-48aa-9a6b-bb1de55a3409)

Also filters out the geometry property from the form fields (still showing in screenshot).