### PR TITLE
Make oskari-frontend a peerDependency to fix import errors

### DIFF
--- a/bundles/analysis/analyse/view/StartAnalyse.ol.js
+++ b/bundles/analysis/analyse/view/StartAnalyse.ol.js
@@ -1,5 +1,5 @@
 import olFormatGeoJSON from 'ol/format/GeoJSON';
-import { COLORS, FILL_COLORS, DEFAULT_STYLE } from './constants';
+import { COLORS, FILL_COLORS } from './constants';
 import { showStyleEditor } from './StyleForm';
 /**
  * @class Oskari.analysis.bundle.analyse.view.StartAnalyse
@@ -906,7 +906,7 @@ Oskari.clazz.define('Oskari.analysis.bundle.analyse.view.StartAnalyse',
                     area : { color }
                 }
             };
-            return jQuery.extend(true, {}, DEFAULT_STYLE, style)
+            return jQuery.extend(true, {}, Oskari.custom.generateBlankStyle(), style)
         },
 
         /**

--- a/bundles/analysis/analyse/view/StyleForm.jsx
+++ b/bundles/analysis/analyse/view/StyleForm.jsx
@@ -5,7 +5,7 @@ import { Message, Button } from 'oskari-ui';
 import { SecondaryButton, PrimaryButton, ButtonContainer } from 'oskari-ui/components/buttons';
 import { showPopup } from 'oskari-ui/components/window';
 import { StyleEditor } from 'oskari-ui/components/StyleEditor';
-import { BUNDLE_KEY, DEFAULT_STYLE } from './constants';
+import { BUNDLE_KEY } from './constants';
 
 const Content = styled.div`
     padding: 24px;
@@ -24,7 +24,7 @@ const StyleForm = ({ style: initStyle, onSave, onCancel, getRandom }) => {
             />
             <ButtonContainer>
                 <Button onClick={() => setStyle(getRandom())}>{getMessage('randomColor')}</Button>
-                <Button onClick={() => setStyle(DEFAULT_STYLE)}>{getMessage('defaultStyle')}</Button>
+                <Button onClick={() => setStyle(Oskari.custom.generateBlankStyle())}>{getMessage('defaultStyle')}</Button>
                 <SecondaryButton type='cancel' onClick={onCancel}/>
                 <PrimaryButton type='save' onClick={() => onSave(style) }/>
             </ButtonContainer>

--- a/bundles/analysis/analyse/view/constants.js
+++ b/bundles/analysis/analyse/view/constants.js
@@ -1,5 +1,3 @@
-import { OSKARI_BLANK_STYLE } from 'oskari-ui/components/StyleEditor/index';
-export const DEFAULT_STYLE = { ...OSKARI_BLANK_STYLE };
 export const BUNDLE_KEY = 'Analyse';
 // Both color arrays have to be equal length
 export const COLORS = [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "Oskari"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "oskari-frontend": "git+https://git@github.com/oskariorg/oskari-frontend.git#develop"
   },
   "engines": {


### PR DESCRIPTION
This makes webpack import files from `node_modules/oskari-frontend` instead of both it and `node_modules/oskari-frontend-contrib/node_modules/oskari-frontend`. We could probably also remove some code from the webpack search path after this.

Also fix references to `OSKARI_BLANK_STYLE` from `oskari-ui/components/StyleEditor/index` as it was removed in https://github.com/oskariorg/oskari-frontend/pull/2363