### PR TITLE
Analysis react fixes

### DIFF
--- a/bundles/analysis/analyse/handler/AnalysisStateHelper.js
+++ b/bundles/analysis/analyse/handler/AnalysisStateHelper.js
@@ -61,7 +61,7 @@ export const getInitMethodParams = (method, layer, targetLayer) => {
 };
 
 export const gatherMethodParams = (state, layer, targetLayer) => {
-    const { method, methodParams, targetId } = state;
+    const { method, methodParams, targetId, layerId } = state;
     if (method === 'union') {
         return {};
     }
@@ -95,7 +95,7 @@ export const gatherMethodParams = (state, layer, targetLayer) => {
     }
     if (method === 'layer_union') {
         return {
-            layers: [targetId],
+            layers: [layerId, targetId],
             ...common
         };
     }

--- a/bundles/analysis/analyse/service/AnalyseService.js
+++ b/bundles/analysis/analyse/service/AnalyseService.js
@@ -62,19 +62,20 @@ Oskari.clazz.define(
                 return;
             }
             // TODO: backend { layer, mergeLayers }
-            const { id, name, mergeLayers = [] } = json;
+            const { id, locale, mergeLayers = [] } = json;
             this._addLayerToService(json);
             // Add layer to the map
             this.sandbox.postRequestByName('AddMapLayerRequest', [id]);
             if (featureData) {
                 this.sandbox.postRequestByName('ShowFeatureDataRequest', [id]);
             }
-            // TODO: is this used anymore??
-            // TODO: shouldn't maplayerservice send removelayer request by default on remove layer?
-            // Remove old layers if any
-            mergeLayers.forEach(layerId => this.sandbox.postRequestByName('RemoveMapLayerRequest', [layerId]));
+            // Remove old layers from map and map layer service
+            mergeLayers.forEach(layerId => {
+                this.mapLayerService.removeLayer(layerId);
+                this.sandbox.postRequestByName('RemoveMapLayerRequest', [layerId]);
+            });
 
-            const layer = Oskari.getLocalized(name)
+            const layer = Oskari.getLocalized(locale)?.name || '';
             Messaging.success(this.loc('AnalyseView.success.layerAdded', { layer }));
         },
 
@@ -103,7 +104,7 @@ Oskari.clazz.define(
             if (!skipEvent) {
                 // notify components of added layer if not suppressed
                 var evt = Oskari.eventBuilder('MapLayerEvent')(null, 'add');
-                sandbox.notifyAll(evt); // add the analysis layers programmatically since normal link processing
+                this.sandbox.notifyAll(evt); // add the analysis layers programmatically since normal link processing
             }
         },
         _handleAnalysisLayersResponse: function (layers = []) {


### PR DESCRIPTION
Fixes for:
https://github.com/oskariorg/oskari-frontend-contrib/pull/104

Changed to remove merged layer also from map layer service. I think that merged layers weren't removed before React changes but it looks that backend removes layers so them have to be removed from service.
https://github.com/oskariorg/oskari-server/blob/master/service-map/src/main/java/fi/nls/oskari/map/analysis/service/AnalysisDbServiceMybatisImpl.java#L272