### PR TITLE
Analysis remove layer filter tool

### DIFF
--- a/bundles/mapping/mapanalysis/plugin/AnalysisLayerPlugin.ol.js
+++ b/bundles/mapping/mapanalysis/plugin/AnalysisLayerPlugin.ol.js
@@ -34,51 +34,13 @@ Oskari.clazz.define(
             const type = this.layertype;
             const options = {
                 type,
-                ...this.loc('layer'),
-                createTools: [layer => this._createFilterTool(layer)]
+                ...this.loc('layer')
             };
             this.getSandbox().getService('Oskari.mapframework.service.MapLayerService')?.registerLayerForUserDataModelBuilder(options);
             // Let wfs plugin handle this layertype
             const wfsPlugin = this.getMapModule().getLayerPlugins('wfs');
             wfsPlugin.registerLayerType(type, 'Oskari.mapframework.bundle.mapanalysis.domain.AnalysisLayer');
             this.unregister();
-        },
-        _createFilterTool: function (layer) {
-            const filterdataTool = Oskari.clazz.create('Oskari.mapframework.domain.Tool');
-            filterdataTool.setName('filterdata');
-            filterdataTool.setIconCls('show-filter-tool');
-            filterdataTool.setTooltip(this.loc('filterTooltip'));
-            filterdataTool.setCallback(() => {
-                const service = this.getSandbox().getService('Oskari.analysis.bundle.analyse.service.AnalyseService');
-                const isAggregateValueAvailable = !!service;
-                const fixedOptions = {
-                    bboxSelection: true,
-                    clickedFeaturesSelection: false,
-                    addLinkToAggregateValues: isAggregateValueAvailable
-                };
-    
-                const filterDialog = Oskari.clazz.create('Oskari.userinterface.component.FilterDialog', fixedOptions);
-                filterDialog.setUpdateButtonHandler((filters) => {
-                    // throw event to new wfs
-                    const filteringChangeEvent = Oskari.eventBuilder('WFSSetPropertyFilter');
-                    this.sandbox.notifyAll(filteringChangeEvent(filters, layer.getId()));
-                });
-    
-                if (isAggregateValueAvailable) {
-                    const aggregateAnalyseFilter = Oskari.clazz.create('Oskari.analysis.bundle.analyse.aggregateAnalyseFilter', filterDialog);
-    
-                    filterDialog.createFilterDialog(layer, null, () =>  {
-                        // FIXME: why is bind() used here? can it be removed?
-                        service._returnAnalysisOfTypeAggregate((listOfAggregateAnalysis) => aggregateAnalyseFilter.addAggregateFilterFunctionality(listOfAggregateAnalysis));
-                    });
-                } else {
-                    filterDialog.createFilterDialog(layer);
-                }
-                filterDialog.setCloseButtonHandler(() => {
-                    filterDialog.popup.dialog.off('click', '.add-link');
-                });
-            });
-            return filterdataTool;
         }
     }, {
         'extend': ['Oskari.mapping.mapmodule.AbstractMapLayerPlugin'],

--- a/bundles/mapping/mapanalysis/plugin/AnalysisLayerPlugin.ol.js
+++ b/bundles/mapping/mapanalysis/plugin/AnalysisLayerPlugin.ol.js
@@ -1,7 +1,3 @@
-import olLayerImage from 'ol/layer/Image';
-import olSourceImageWMS from 'ol/source/ImageWMS';
-import { getZoomLevelHelper } from 'oskari-frontend/bundles/mapping/mapmodule/util/scale';
-
 /**
  * @class Oskari.mapframework.bundle.mapanalysis.plugin.AnalysisLayerPlugin
  * Provides functionality to draw Analysis layers on the map


### PR DESCRIPTION
Remove `Filter data` layer tool from Analysis layers. Tool causes JS error. `sandbox` could be replaced to `getSandbox()` get it work. However it uses old jQuery based filter dialog and it's only shortcut for Feature data -> Filter. If filter tool is needed/wanted maybe we could add shortcut for WFS layer (not only for Analysis).

Also cleaned unused imports

![image](https://github.com/oskariorg/oskari-frontend-contrib/assets/22147092/3140e278-ce05-4298-ad81-82af99804a7b)
