### PR TITLE
Analysis layers response event fix

### DIFF
--- a/bundles/analysis/analyse/service/AnalyseService.js
+++ b/bundles/analysis/analyse/service/AnalyseService.js
@@ -96,16 +96,11 @@ Oskari.clazz.define(
                 Messaging.error(this.loc('AnalyseView.error.loadLayersFailed'));
             });
         },
-        _addLayerToService: function (layerJson, skipEvent) {
+        _addLayerToService: function (layerJson, suppressEvent) {
             // Create the layer model
             const layer = this.mapLayerService.createMapLayer(layerJson);
             // Add the layer to the map layer service
-            this.mapLayerService.addLayer(layer);
-            if (!skipEvent) {
-                // notify components of added layer if not suppressed
-                var evt = Oskari.eventBuilder('MapLayerEvent')(null, 'add');
-                this.sandbox.notifyAll(evt); // add the analysis layers programmatically since normal link processing
-            }
+            this.mapLayerService.addLayer(layer, suppressEvent);
         },
         _handleAnalysisLayersResponse: function (layers = []) {
             layers.forEach(layer => this._addLayerToService(layer, true));


### PR DESCRIPTION
Pass suppressEvent to avoid _handleAnalysisLayersResponse to trigger MapLayerEvent for every layer as maplayer service triggers it without suppressEvent. Also event should have layerId instead of null for single layer. _handleAnalysisLayersResponse triggers mass update event.

https://github.com/oskariorg/oskari-frontend/blob/master/bundles/mapping/mapmodule/service/map.layer.js#L176-L180