### PR TITLE
Change icon position to avoid overlap

### DIFF
--- a/bundles/tampere/selected-featuredata/resources/css/style.css
+++ b/bundles/tampere/selected-featuredata/resources/css/style.css
@@ -2,8 +2,8 @@
 	cursor: pointer;
 	background: url("../images/icon-selected-featuredata-valk.png");
 	position: absolute; 
-	top: 12px; 
-	right: 23px; 
+	top: 8px; 
+	right: 40px; 
 	width: 20px; 
 	height: 20px;
 }


### PR DESCRIPTION
Tampere bundle `selected-featuredata` is experiencing an akward icon overlap in pop up window. This PR aims to fix that by moving bundle icon further left and down to give space for icon that closes the pop up. 

![image](https://github.com/user-attachments/assets/8f82e006-1aaa-4b6d-a78e-fc89a57da79e)